### PR TITLE
Layout adjustments to A320 limitations page

### DIFF
--- a/css/A320limitations.css
+++ b/css/A320limitations.css
@@ -100,6 +100,9 @@ caption {
      their container. You need to specify a width if you want it
      to do so. */
   width: 100%;
+  /* instead of adding `<br>` tags after tables, put a margin on
+     the bottom of the table. */
+  margin-bottom: 20px;
 }
 
 

--- a/css/A320limitations.css
+++ b/css/A320limitations.css
@@ -93,7 +93,13 @@ caption {
 
 .tables {
 	margin: 1em auto;
-	
+}
+
+.tables table {
+  /* tables will not automatically expand to the full width of
+     their container. You need to specify a width if you want it
+     to do so. */
+  width: 100%;
 }
 
 

--- a/html/A320limitations.html
+++ b/html/A320limitations.html
@@ -18,8 +18,8 @@
 	<div class="wrap clearfix">
 		<header>
 			<h1 id="titlepage">Airbus Notes</h1>
-				<img class="featuredimg" src="../img/A320large.png" alt="stock A320 photo" style="width:400px;height:auto;">
-				<!--<img src="../img/tinyjetblue.jpg" alt="jetblue A320 in flight">-->
+			<img class="featuredimg" src="../img/A320large.png" alt="stock A320 photo" style="width:400px;height:auto;">
+			<!--<img src="../img/tinyjetblue.jpg" alt="jetblue A320 in flight">-->
 			<nav>
 				<ul style="list-style-type: none" class="main-nav">
 					<li><a href="index.html">Home</a></li>
@@ -32,7 +32,7 @@
 			</nav>
 
 			<nav id="menu">
-					<select>
+				<select>
 						<option><a href="index.html">Home</a></option>
 						<option><a href="A320memory.html">A320 Memory Items</a></option>
 						<option><a href="A320limitations.html">A320 Limitations</a></option>
@@ -45,575 +45,570 @@
 
 		<div class="container clearfix">
 
-					<h3 style="text-align: center"><a href="memoryquiz.html" id="takequiz">LIMITATIONS</a></h3>
+			<h3 style="text-align: center"><a href="memoryquiz.html" id="takequiz">LIMITATIONS</a></h3>
 
-					<div>
-						<table id="weights">
-							<caption>Weights</caption>
-							<thead>
-								<tr>
-									<th scope="col"></th>
-									<th scope="col"><b>A320 - WV10</b></th>
-									<th scope="col"><b>A320 - WV15</b></th>
-									<th scope="col"><b>A320 - WV12</b></th>
-									<th scope="col"><b>A320 - WV17</b></th>
-									<th scope="col"><b>A321 - WV11</b></th>
-								</tr>
-							</thead>
-							<tfoot>
-								<tr>
-									<td colspan="6">Data source: JetBlue QRH</td>
-								</tr>
-							</tfoot>
-							<tbody>
-								<tr>
-									<th class="table" scope="row"><b>Max Taxi</b></th>
-									<td>170,637 lb</td>
-									<td>172,842 lb</td>
-									<td>170,637 lb</td>
-									<td>172,842 lb</td>
-									<td>207,014 lb</td>
-								</tr>
-								<tr>
-									<th class="table" scope="row"><b>Max Takeoff</b></th>
-									<td>169,755 lb</td>
-									<td>171,960 lb</td>
-									<td>169,755 lb</td>
-									<td>171,960 lb</td>
-									<td>206,132 lb</td>
-								</tr>
-								<tr>
-									<th class="table" scope="row"><b>Max Landing</b></th>
-									<td>142,198 lb</td>
-									<td>142,198 lb</td>
-									<td>145,505 lb</td>
-									<td>145,505 lb</td>
-									<td>171,519 lb</td>
-								</tr>
-								<tr>
-									<th class="table" scope="row"><b>Max Zero Fuel</b></th>
-									<td>134,481 lb</td>
-									<td>134,481 lb</td>
-									<td>137,788 lb</td>
-									<td>137,788 lb</td>
-									<td>162,701 lb</td>
-								</tr>
-								<tr>
-									<th class="table" scope="row"><b>Min Weight</b></th>
-									<td>82,079 lb</td>
-									<td>82,079 lb</td>
-									<td>82,079 lb</td>
-									<td>82,079 lb</td>
-									<td>104,720 lb</td>
-								</tr>
-							</tbody>
-						</table>
+			<div>
+				<table id="weights">
+					<caption>Weights</caption>
+					<thead>
+						<tr>
+							<th scope="col"></th>
+							<th scope="col"><b>A320 - WV10</b></th>
+							<th scope="col"><b>A320 - WV15</b></th>
+							<th scope="col"><b>A320 - WV12</b></th>
+							<th scope="col"><b>A320 - WV17</b></th>
+							<th scope="col"><b>A321 - WV11</b></th>
+						</tr>
+					</thead>
+					<tfoot>
+						<tr>
+							<td colspan="6">Data source: JetBlue QRH</td>
+						</tr>
+					</tfoot>
+					<tbody>
+						<tr>
+							<th class="table" scope="row"><b>Max Taxi</b></th>
+							<td>170,637 lb</td>
+							<td>172,842 lb</td>
+							<td>170,637 lb</td>
+							<td>172,842 lb</td>
+							<td>207,014 lb</td>
+						</tr>
+						<tr>
+							<th class="table" scope="row"><b>Max Takeoff</b></th>
+							<td>169,755 lb</td>
+							<td>171,960 lb</td>
+							<td>169,755 lb</td>
+							<td>171,960 lb</td>
+							<td>206,132 lb</td>
+						</tr>
+						<tr>
+							<th class="table" scope="row"><b>Max Landing</b></th>
+							<td>142,198 lb</td>
+							<td>142,198 lb</td>
+							<td>145,505 lb</td>
+							<td>145,505 lb</td>
+							<td>171,519 lb</td>
+						</tr>
+						<tr>
+							<th class="table" scope="row"><b>Max Zero Fuel</b></th>
+							<td>134,481 lb</td>
+							<td>134,481 lb</td>
+							<td>137,788 lb</td>
+							<td>137,788 lb</td>
+							<td>162,701 lb</td>
+						</tr>
+						<tr>
+							<th class="table" scope="row"><b>Min Weight</b></th>
+							<td>82,079 lb</td>
+							<td>82,079 lb</td>
+							<td>82,079 lb</td>
+							<td>82,079 lb</td>
+							<td>104,720 lb</td>
+						</tr>
+					</tbody>
+				</table>
 
-						
-						<table id="oplimits">
-								<caption>Operational Limits</caption>
-								<tr>
-									<td>Min flight crew</td>
-									<td align="right">2</td>
-								</tr>
-								<tr>
-									<td><b>Max tailwind</b></td>
-									<td align="right"><b>Takoff 15 kts / Landing 10kts</b></td>
-								</tr>
-								<tr>
-									<td>Max wind pax door operation</td>
-									<td align="right">65 kts</td>
-								</tr>
-								<tr>
-									<td>Max wind cargo door ops (open)</td>
-									<td align="right">40 kts</td>
-								</tr>
-								<tr>
-									<td>Max wind cargo door ops (close)</td>
-									<td align="right">65 kts</td>
-								</tr>
-								<tr>
-									<td><b>Max crosswind takeoff and landing (dry or damp runway)</b></td>
-									<td align="right"><b>38 kts (gust included)</b></td>
-								</tr>
-								<tr>
-									<td><b>Aircraft ceiling</b></td>
-									<td align="right"><b>39,100 ft</b></td>
-								</tr>
-								<tr>
-									<td>Minimum runway width</td>
-									<td align="right">148 ft / 45 meters&#42</td>
-								</tr>
-							</table>
-						
-						<br>
-					</div>
-						
-					
-						<section class="primary col">
+				<table id="oplimits">
+					<caption>Operational Limits</caption>
+					<tr>
+						<td>Min flight crew</td>
+						<td align="right">2</td>
+					</tr>
+					<tr>
+						<td><b>Max tailwind</b></td>
+						<td align="right"><b>Takoff 15 kts / Landing 10kts</b></td>
+					</tr>
+					<tr>
+						<td>Max wind pax door operation</td>
+						<td align="right">65 kts</td>
+					</tr>
+					<tr>
+						<td>Max wind cargo door ops (open)</td>
+						<td align="right">40 kts</td>
+					</tr>
+					<tr>
+						<td>Max wind cargo door ops (close)</td>
+						<td align="right">65 kts</td>
+					</tr>
+					<tr>
+						<td><b>Max crosswind takeoff and landing (dry or damp runway)</b></td>
+						<td align="right"><b>38 kts (gust included)</b></td>
+					</tr>
+					<tr>
+						<td><b>Aircraft ceiling</b></td>
+						<td align="right"><b>39,100 ft</b></td>
+					</tr>
+					<tr>
+						<td>Minimum runway width</td>
+						<td align="right">148 ft / 45 meters&#42</td>
+					</tr>
+				</table>
+			</div>
 
-							<div class="tables">
-								<table>
-									<tr>
-										<td><b><i>Runway Slope</i></b></td>
-									</tr>
-									<tr>
-										<td>Max</td>
-										<td align="right">-2.0%, +2.0%</td>
-									</tr>
-									<tr style="height: 30px"></tr>
-										
-									
-									<td><b><i>Limit Maneuvering Load Factors</i></b></td>
-									<td></td>
-									</tr>
+			<div class="container">
+				<section class="primary col">
+					<div class="tables">
+						<table>
+							<tr>
+								<td><b><i>Runway Slope</i></b></td>
+							</tr>
+							<tr>
+								<td>Max</td>
+								<td align="right">-2.0%, +2.0%</td>
+							</tr>
+							<tr style="height: 30px">
+								<td><b><i>Limit Maneuvering Load Factors</i></b></td>
+								<td></td>
+							</tr>
 
-									<tr>
-										<td>Clean configuration</td>
-										<td align="right">-1g to +2.5g</td>
-									</tr>
-									<tr>
-										<td>Slats and Flaps extended</td>
-										<td align="right">0g to +2.0g</td>
-									</tr>
-									<tr>
-										<td>Slats and Flaps retracted</td>
-										<td align="right">0g to +2.0g</td>
-									</tr>
+							<tr>
+								<td>Clean configuration</td>
+								<td align="right">-1g to +2.5g</td>
+							</tr>
+							<tr>
+								<td>Slats and Flaps extended</td>
+								<td align="right">0g to +2.0g</td>
+							</tr>
+							<tr>
+								<td>Slats and Flaps retracted</td>
+								<td align="right">0g to +2.0g</td>
+							</tr>
 
-									<tr style="height: 30px"></tr>
-							
-									<tr>
-										<td><b><i>Fuel</i></b></td>
-									</tr>
-									<tr>
-										<td>Min fuel temperature</td>
-										<td align="right">-36&#8451</td>
-									</tr>
-									<tr>
-										<td>Min fuel quantity for takeoff</td>
-										<td align="right">3307 lb</td>
-									</tr>
-									<tr>	
-										<td>Max allowable fuel imb tanks full:</td>
-									</tr>
-									<tr>
-										<td>All phases of flight</td>
-										<td align="right">3306 lb (A320 non-Sharklet)</td>
-									</tr>
-									<tr>
-										<td>Takeoff</td>
-										<td align="right">1102 lb (A320 Sharklet)</td>
-									</tr>
-									<tr>
-										<td>In-flight / landing</td>
-										<td align="right">3306 lb (A320 Sharklet)</td>
-									</tr>
-									<tr>
-										<td>Takeoff</td>
-										<td align="right">882 lb (A321)</td>
-									</tr>
-									<tr>
-										<td>In-flight / landing</td>
-										<td align="right">2910 lb (A321)</td>
-									</tr>
-							
-									<tr style="height: 30px"></tr>
+							<tr style="height: 30px"></tr>
 
+							<tr>
+								<td><b><i>Fuel</i></b></td>
+							</tr>
+							<tr>
+								<td>Min fuel temperature</td>
+								<td align="right">-36&#8451</td>
+							</tr>
+							<tr>
+								<td>Min fuel quantity for takeoff</td>
+								<td align="right">3307 lb</td>
+							</tr>
+							<tr>
+								<td>Max allowable fuel imb tanks full:</td>
+							</tr>
+							<tr>
+								<td>All phases of flight</td>
+								<td align="right">3306 lb (A320 non-Sharklet)</td>
+							</tr>
+							<tr>
+								<td>Takeoff</td>
+								<td align="right">1102 lb (A320 Sharklet)</td>
+							</tr>
+							<tr>
+								<td>In-flight / landing</td>
+								<td align="right">3306 lb (A320 Sharklet)</td>
+							</tr>
+							<tr>
+								<td>Takeoff</td>
+								<td align="right">882 lb (A321)</td>
+							</tr>
+							<tr>
+								<td>In-flight / landing</td>
+								<td align="right">2910 lb (A321)</td>
+							</tr>
 
-								
-								<table>
-									<caption>Speeds</caption>
-									<tr>
-										<td>Max flap speed config 1</td>
-										<td align="right">230 kts (A320) / 235 kts (A321)</td>
-									</tr>
+							<tr style="height: 30px"></tr>
+
+							<tr>
+								<td>
+									<table>
+										<caption>Speeds</caption>
+										<tr>
+											<td>Max flap speed config 1</td>
+											<td align="right">230 kts (A320) / 235 kts (A321)</td>
+										</tr>
 										<td>Max flap speed config 1+F</td>
 										<td align="right">215 kts(A320)</td>
-									<tr>
-										<td></td>
-										<td align="right">225 kts (A321)</td>
-									</tr>
-									<tr>
-										<td>Max flap speed config 2</td>
-										<td align="right">200 kts (A320)</td>
-									</tr>
-									<tr>
-										<td></td>
-										<td align="right">215 kts (A321)</td>
-									</tr>
-									<tr>
-										<td>Max flap speed config 3</td>
-										<td align="right">185 kts (A320)</td>
-									</tr>
-									<tr>
-										<td></td>
-										<td align="right">195 kts (A321)</td>
-									</tr>
-									<tr>
-										<td>Max flap speed config full</td>
-										<td align="right">177 kts (A320)</td>
-									</tr>
-									<tr>
-										<td></td>
-										<td align="right">190 kts (A321)</td>
-									</tr>
-									<tr>
-										<td>V<sub>LE</sub></td>
-										<td align="right">280 kts / 0.67M</td>
-									</tr>
-									<tr>
-										<td>V<sub>LO extension / retraction</sub></td>
-										<td align="right">250 kts / 220 kts</td>
-									</tr>
-									<tr>
-										<td>V<sub>MO</sub></td>
-										<td align="right">350 kts / 0.82M</td>
-									</tr>
-									<tr>
-										<td>Max cockpit window open speed</td>
-										<td align="right">200 kts</td>
-									</tr>
-									<tr>
-										<td>Max tire speed (ground speed)</td>
-										<td align="right">195 kts</td>
-									</tr>
-									<tr>
-										<td><b>Max windshield wiper speed</b></td>
-										<td align="right"><b>230 kts</b></td>
-									</tr>
-								</table>
-						</div>
+										<tr>
+											<td></td>
+											<td align="right">225 kts (A321)</td>
+										</tr>
+										<tr>
+											<td>Max flap speed config 2</td>
+											<td align="right">200 kts (A320)</td>
+										</tr>
+										<tr>
+											<td></td>
+											<td align="right">215 kts (A321)</td>
+										</tr>
+										<tr>
+											<td>Max flap speed config 3</td>
+											<td align="right">185 kts (A320)</td>
+										</tr>
+										<tr>
+											<td></td>
+											<td align="right">195 kts (A321)</td>
+										</tr>
+										<tr>
+											<td>Max flap speed config full</td>
+											<td align="right">177 kts (A320)</td>
+										</tr>
+										<tr>
+											<td></td>
+											<td align="right">190 kts (A321)</td>
+										</tr>
+										<tr>
+											<td>V<sub>LE</sub></td>
+											<td align="right">280 kts / 0.67M</td>
+										</tr>
+										<tr>
+											<td>V<sub>LO extension / retraction</sub></td>
+											<td align="right">250 kts / 220 kts</td>
+										</tr>
+										<tr>
+											<td>V<sub>MO</sub></td>
+											<td align="right">350 kts / 0.82M</td>
+										</tr>
+										<tr>
+											<td>Max cockpit window open speed</td>
+											<td align="right">200 kts</td>
+										</tr>
+										<tr>
+											<td>Max tire speed (ground speed)</td>
+											<td align="right">195 kts</td>
+										</tr>
+										<tr>
+											<td><b>Max windshield wiper speed</b></td>
+											<td align="right"><b>230 kts</b></td>
+										</tr>
+									</table>
+								</td>
+							</tr>
+						</table>
 
 						<div class="tables">
-								<table>
-									<caption>Landing Gear</caption>
-									<tr>
-										<td>Max brake temp for takeoff (fans off)</td>
-										<td align="right">300&#8451</td>
-									</tr>
-									<tr>
-										<td>Max EPR with parking brake set</td>
-										<td align="right">1.18 on both</td>
-									</tr>
-									<tr>
-										<td>Max taxi speed turn > 167,500 lb</td>
-										<td align="right">20 kts</td>
-									</tr>
-								</table>
+							<table>
+								<caption>Landing Gear</caption>
+								<tr>
+									<td>Max brake temp for takeoff (fans off)</td>
+									<td align="right">300&#8451</td>
+								</tr>
+								<tr>
+									<td>Max EPR with parking brake set</td>
+									<td align="right">1.18 on both</td>
+								</tr>
+								<tr>
+									<td>Max taxi speed turn > 167,500 lb</td>
+									<td align="right">20 kts</td>
+								</tr>
+							</table>
 						</div>
+					</div>
+				</section>
+				<section class="secondary col">
+					<div class="tables">
+						<table>
+							<caption>Oxygen</caption>
+							<tr>
+								<td>Crew O<sub>2</sub> limits</td>
+								<td align="right">See table pg. A-30</td>
+							</tr>
+						</table>
+					</div>
 
-								<br>
+					<div class="tables">
+						<table>
+							<caption>Hydraulics</caption>
+							<tr>
+								<td>Normal HYD operating pressure</td>
+								<td align="right">3000 +/- 200 psi</td>
+							</tr>
+						</table>
+					</div>
 
-						<div class="tables">
-								<table>
-									<caption>Oxygen</caption>
-									<tr>
-										<td>Crew O<sub>2</sub> limits</td>
-										<td align="right">See table pg. A-30</td>
-									</tr>
-								</table>
-						</div>
-							
-								<br>
+					<br>
 
-						
-					</section>
+					<div class="tables">
+						<table>
+							<caption>Electric</caption>
+							<tr>
+								<td>Max cont. load per generator</td>
+								<td align="right">100% (90 kVa)</td>
+							</tr>
+							<tr>
+								<td>Max cont. load per TR</td>
+								<td align="right">200 amps</td>
+							</tr>
+						</table>
+					</div>
 
-							<br>
+					<br>
 
-					<section class="secondary col">
+					<div class="tables">
+						<table>
+							<caption>Altitudes</caption>
+							<tr>
+								<td>Max altitude for gear extension</td>
+								<td align="right">25,000 ft</td>
+							</tr>
+							<tr>
+								<td>Max altitude slat / flap extension</td>
+								<td align="right">FL200</td>
+							</tr>
+							<tr>
+								<td>Runway altitude</td>
+								<td align="right">+9200 ft</td>
+							</tr>
+						</table>
+					</div>
 
-						<div class="tables">
-								<table>
-									<caption>Hydraulics</caption>
-									<tr>
-										<td>Normal HYD operating pressure</td>
-										<td align="right">3000 +/- 200 psi</td>
-									</tr>
-								</table>
-						</div>
+					<br>
 
-								<br>
+					<div class="tables">
+						<table>
+							<caption>Autoflight</caption>
+							<tr>
+								<td>Min height AP on for takeoff / SRS</td>
+								<td align="right">100 ft AGL</td>
+							</tr>
+							<tr>
+								<td>Min height AP Straight-in Non-precision Approach</td>
+								<td align="right">Applicable MDA (MDH)</td>
+							</tr>
+							<tr>
+								<td>Min height AP Circling Approach</td>
+								<td align="right">Applicable MDA - 100 ft</td>
+							</tr>
+							<tr>
+								<td>Min height AP ILS (CAT I FMA)</td>
+								<td align="right">160 ft AGL</td>
+							</tr>
+							<tr>
+								<td>Max Autoland Elevation</td>
+								<td align="right">6500 ft (A320)</td>
+							</tr>
+							<tr>
+								<td></td>
+								<td align="right">5750 ft (A321)</td>
+							</tr>
+							<tr>
+								<td>Min height AP for Go Around</td>
+								<td align="right">100 ft AGL</td>
+							</tr>
+							<tr>
+								<td>All other phases</td>
+								<td align="right">500 ft AGL (A320)</td>
+							</tr>
+							<tr>
+								<td></td>
+								<td align="right">900 ft AGL (A321)</td>
+							</tr>
+							<tr>
+								<td>CAT II Min DH</td>
+								<td align="right">100 ft AGL</td>
+							</tr>
+							<tr>
+								<td>CAT III Dual Alert Height</td>
+								<td align="right">100 ft</td>
+							</tr>
+							<tr>
+								<td>CAT III Minimum RVR</td>
+								<td align="right">247 ft / 75 meters</td>
+							</tr>
+							<tr>
+								<td>Max Winds auto approach, landing, rollout</td>
+								<td align="right"> HW 30/TW 10/XW 15 kts</td>
+							</tr>
+						</table>
+					</div>
 
-						<div class="tables">
-								<table>
-									<caption>Electric</caption>
-									<tr>
-										<td>Max cont. load per generator</td>
-										<td align="right">100% (90 kVa)</td>
-									</tr>
-									<tr>
-										<td>Max cont. load per TR</td>
-										<td align="right">200 amps</td>
-									</tr>
-								</table>
-						</div>
+					<br>
 
-								<br>
-
-						<div class="tables">
-								<table>
-									<caption>Altitudes</caption>
-									<tr>
-										<td>Max altitude for gear extension</td>
-										<td align="right">25,000 ft</td>
-									</tr>
-									<tr>
-										<td>Max altitude slat / flap extension</td>
-										<td align="right">FL200</td>
-									</tr>
-									<tr>
-										<td>Runway altitude</td>
-										<td align="right">+9200 ft</td>
-									</tr>
-								</table>
-						</div>
-
-								<br>
-
-						<div class="tables">
-								<table>
-									<caption>Autoflight</caption>
-									<tr>
-										<td>Min height AP on for takeoff / SRS</td>
-										<td align="right">100 ft AGL</td>
-									</tr>
-									<tr>
-										<td>Min height AP Straight-in Non-precision Approach</td>
-										<td align="right">Applicable MDA (MDH)</td>
-									</tr>
-									<tr>
-										<td>Min height AP Circling Approach</td>
-										<td align="right">Applicable MDA - 100 ft</td>
-									</tr>
-									<tr>
-										<td>Min height AP ILS (CAT I FMA)</td>
-										<td align="right">160 ft AGL</td>
-									</tr>
-									<tr>
-										<td>Max Autoland Elevation</td>
-										<td align="right">6500 ft (A320)</td>
-									</tr>
-									<tr>
-										<td></td>
-										<td align="right">5750 ft (A321)</td>
-									</tr>
-									<tr>
-										<td>Min height AP for Go Around</td>
-										<td align="right">100 ft AGL</td>
-									</tr>
-									<tr>
-										<td>All other phases</td>
-										<td align="right">500 ft AGL (A320)</td>
-									</tr>
-									<tr>
-										<td></td>
-										<td align="right">900 ft AGL (A321)</td>
-									</tr>
-									<tr>
-										<td>CAT II Min DH</td>
-										<td align="right">100 ft AGL</td>
-									</tr>
-									<tr>
-										<td>CAT III Dual Alert Height</td>
-										<td align="right">100 ft</td>
-									</tr>
-									<tr>
-										<td>CAT III Minimum RVR</td>
-										<td align="right">247 ft / 75 meters</td>
-									</tr>
-									<tr>
-										<td>Max Winds auto approach, landing, rollout</td>
-										<td align="right"> HW 30/TW 10/XW 15 kts</td>
-									</tr>
-								</table>
-						</div>
-
-								<br>
-
-						<div class="tables">
-								<table id="APU">
-									<caption>APU</caption>
-									<tr>
-										<td>Min APU oil quantity before start</td>
-										<td align="right">LOW OIL LEVEL not displayed</td>
-									</tr>
-									<tr>
-										<td>APU ops with "LOW OIL LEVEL"</td>
-										<td align="right">10 hours</td>
-									</tr>
-									<tr>
-										<td>APU start cycles</td>
-										<td align="right">3 starter motor duty cycles, 60 min off</td>
-									</tr>
-									<tr>
-										<td>Max N (ECAM display)</td>
-										<td align="right">107%</td>
-									</tr>
-									<tr>
-										<td>Max EGT</td>
-										<td align="right">675&#8451</td>
-									</tr>
-									<tr>
-										<td>Max EGT starting < 35,000 ft</td>
+					<div class="tables">
+						<table id="APU">
+							<caption>APU</caption>
+							<tr>
+								<td>Min APU oil quantity before start</td>
+								<td align="right">LOW OIL LEVEL not displayed</td>
+							</tr>
+							<tr>
+								<td>APU ops with "LOW OIL LEVEL"</td>
+								<td align="right">10 hours</td>
+							</tr>
+							<tr>
+								<td>APU start cycles</td>
+								<td align="right">3 starter motor duty cycles, 60 min off</td>
+							</tr>
+							<tr>
+								<td>Max N (ECAM display)</td>
+								<td align="right">107%</td>
+							</tr>
+							<tr>
+								<td>Max EGT</td>
+								<td align="right">675&#8451</td>
+							</tr>
+							<tr>
+								<td>Max EGT starting
+									< 35,000 ft</td>
 										<td align="right">1090&#8451</td>
-									</tr>
-									<tr>
-										<td>Max EGT starting > 35,000 ft</td>
-										<td align="right">1120&#8451</td>
-									</tr>
-									<tr>
-										<td>Max alt to power elec and bleed air</td>
-										<td align="right">22,500 ft (1 pck) / 15,000 (2 pcks)</td>
-									</tr>
-								</table>
-						</div>
-					</section>
+							</tr>
+							<tr>
+								<td>Max EGT starting > 35,000 ft</td>
+								<td align="right">1120&#8451</td>
+							</tr>
+							<tr>
+								<td>Max alt to power elec and bleed air</td>
+								<td align="right">22,500 ft (1 pck) / 15,000 (2 pcks)</td>
+							</tr>
+						</table>
+					</div>
+				</section>
+				<section class="tertiary col">
+					<div class="tables">
+						<table id="engine">
+							<caption>Engine</caption>
+							<tr>
+								<td>EGT takeoff and go around</td>
+								<td align="right">635&#8451 5 mins (10 mins E/O) (A320)</td>
+							</tr>
+							<tr>
+								<td></td>
+								<td align="right">650&#8451 5 mins (10 mins E/O) (A321)</td>
+							</tr>
+							<tr>
+								<td>EGT MCT</td>
+								<td align="right">610&#8451</td>
+							</tr>
+							<tr>
+								<td>EGT starting</td>
+								<td align="right">635&#8451</td>
+							</tr>
+							<tr>
+								<td>Min starting oil temp</td>
+								<td align="right">-40&#8451</td>
+							</tr>
+							<tr>
+								<td>Min oil temp prior to exceeding idle</td>
+								<td align="right">-10&#8451</td>
+							</tr>
+							<tr>
+								<td>Min oil temp prior to takeoff</td>
+								<td align="right">50&#8451</td>
+							</tr>
+							<tr>
+								<td>Max continuous oil temp</td>
+								<td align="right">155&#8451</td>
+							</tr>
+							<tr>
+								<td>Max transient oil temp</td>
+								<td align="right">165&#8451 (15 mins)</td>
+							</tr>
+							<tr>
+								<td>Min oil quantity</td>
+								<td align="right">refer to FCOM</td>
+							</tr>
+							<tr>
+								<td>Min oil pressure</td>
+								<td align="right">60 psi</td>
+							</tr>
+							<tr>
+								<td>Max crosswind for engine start</td>
+								<td align="right">35 kts</td>
+							</tr>
+							<tr>
+								<td>Max N1 and N2</td>
+								<td align="right">100% for both</td>
+							</tr>
+							<tr>
+								<td>Running engagement of starter</td>
+								<td align="right">Grnd &#8805 N2 / Flt 18% N2</td>
+							</tr>
+							<tr>
+								<td>Reverse thrust in flight</td>
+								<td align="right">Prohibited</td>
+							</tr>
+							<tr>
+								<td>Backing up with reverse thrust</td>
+								<td align="right">Prohibited</td>
+							</tr>
+							<tr>
+								<td>Maximum reverse thrust on landing</td>
+								<td align="right">Not below 70 kts, idle stop</td>
+							</tr>
+							<tr>
+								<td>Reduced thrust limits</td>
+								<td align="right">Refer to FCOM</td>
+							</tr>
+							<tr>
+								<td><b>Starter Cycles</b></td>
+								<td align="right"><b>2 min on, 15 sec off, 2 min on, 15 sec off, 1 min on, 30 min off</b></td>
+							</tr>
+							<tr>
+								<td></td>
+								<td align="right">or</td>
+							</tr>
+							<tr>
+								<td></td>
+								<td align="right"><b>Continuous Cranking for 4 min on, 30 min off</b></td>
+							</tr>
+						</table>
+					</div>
 
-							<br>
+					<br>
 
-					<section class="tertiary col">
-					
-						<div class="tables">
-								<table id="engine">
-									<caption>Engine</caption>
-									<tr>
-										<td>EGT takeoff and go around</td>
-										<td align="right">635&#8451 5 mins (10 mins E/O) (A320)</td>
-									</tr>
-									<tr>
-										<td></td>
-										<td align="right">650&#8451 5 mins (10 mins E/O) (A321)</td>
-									</tr>
-									<tr>
-										<td>EGT MCT</td>
-										<td align="right">610&#8451</td>
-									</tr>
-									<tr>
-										<td>EGT starting</td>
-										<td align="right">635&#8451</td>
-									</tr>
-									<tr>
-										<td>Min starting oil temp</td>
-										<td align="right">-40&#8451</td>
-									</tr>
-									<tr>
-										<td>Min oil temp prior to exceeding idle</td>
-										<td align="right">-10&#8451</td>
-									</tr>
-									<tr>
-										<td>Min oil temp prior to takeoff</td>
-										<td align="right">50&#8451</td>
-									</tr>
-									<tr>
-										<td>Max continuous oil temp</td>
-										<td align="right">155&#8451</td>
-									</tr>
-									<tr>
-										<td>Max transient oil temp</td>
-										<td align="right">165&#8451 (15 mins)</td>
-									</tr>
-									<tr>
-										<td>Min oil quantity</td>
-										<td align="right">refer to FCOM</td>
-									</tr>
-									<tr>
-										<td>Min oil pressure</td>
-										<td align="right">60 psi</td>
-									</tr>
-									<tr>
-										<td>Max crosswind for engine start</td>
-										<td align="right">35 kts</td>
-									</tr>
-									<tr>
-										<td>Max N1 and N2</td>
-										<td align="right">100% for both</td>
-									</tr>
-									<tr>
-										<td>Running engagement of starter</td>
-										<td align="right">Grnd &#8805 N2 / Flt 18% N2</td>
-									</tr>
-									<tr>
-										<td>Reverse thrust in flight</td>
-										<td align="right">Prohibited</td>
-									</tr>
-									<tr>
-										<td>Backing up with reverse thrust</td>
-										<td align="right">Prohibited</td>
-									</tr>
-									<tr>
-										<td>Maximum reverse thrust on landing</td>
-										<td align="right">Not below 70 kts, idle stop</td>
-									</tr>
-									<tr>
-										<td>Reduced thrust limits</td>
-										<td align="right">Refer to FCOM</td>
-									</tr>
-									<tr>
-										<td><b>Starter Cycles</b></td>
-										<td align="right"><b>2 min on, 15 sec off, 2 min on, 15 sec off, 1 min on, 30 min off</b></td>
-									</tr>
-									<tr>
-										<td></td>
-										<td align="right">or</td>
-									</tr>
-									<tr>
-										<td></td>
-										<td align="right"><b>Continuous Cranking for 4 min on, 30 min off</b></td>
-									</tr>
-								</table>
-						</div>		
-						
-								<br>
+					<div class="tables">
+						<table id="air">
+							<caption>Air / Pressurization / Ventilation</caption>
+							<tr>
+								<td>Ram air inlet open</td>
+								<td align="right">Diff press
+									< 1.0 psi</td>
+							</tr>
+							<tr>
+								<td>Avionics ventilation limits during grnd ops</td>
+								<td align="right">Refer to FCOM</td>
+							</tr>
+							<tr>
+								<td><b>Simultaneous use of AC packs & LP ground cart</b></td>
+								<td align="right"><b>Prohibited</b></td>
+							</tr>
+							<tr>
+								<td><b>Simultaneous use of APU pneumatic & HP cart</b></td>
+								<td align="right"><b>Prohibited</b></td>
+							</tr>
+							<tr>
+								<td>Max positive differential pressure</td>
+								<td align="right">9.0 psi</td>
+							</tr>
+							<tr>
+								<td>Max negative differential pressure</td>
+								<td align="right">-1 psi</td>
+							</tr>
+							<tr>
+								<td>Safety relief valve setting</td>
+								<td align="right">8.6 psi</td>
+							</tr>
+						</table>
+					</div>
+				</section>
+			</div>
 
-						<div class="tables">
-								<table id="air">
-									<caption>Air / Pressurization / Ventilation</caption>
-									<tr>
-										<td>Ram air inlet open</td>
-										<td align="right">Diff press < 1.0 psi</td>
-									</tr>
-									<tr>
-										<td>Avionics ventilation limits during grnd ops</td>
-										<td align="right">Refer to FCOM</td>
-									</tr>
-									<tr>
-										<td><b>Simultaneous use of AC packs & LP ground cart</b></td>
-										<td align="right"><b>Prohibited</b></td>
-									</tr>
-									<tr>
-										<td><b>Simultaneous use of APU pneumatic & HP cart</b></td>
-										<td align="right"><b>Prohibited</b></td>
-									</tr>
-									<tr>
-										<td>Max positive differential pressure</td>
-										<td align="right">9.0 psi</td>
-									</tr>
-									<tr>
-										<td>Max negative differential pressure</td>
-										<td align="right">-1 psi</td>
-									</tr>
-									<tr>
-										<td>Safety relief valve setting</td>
-										<td align="right">8.6 psi</td>
-									</tr>
-								</table>
-						</div>
-					</section>
+
+
+			<br>
+
+
+
 
 		</div>
-		
+	</div>
 
-		
 
-		</div>
 
-<script type="text/javascript" src="../js/memoryquiz.js"></script>
 
-		<footer>
-			<p>&copy; 2017 by <a href="contact.html">AirbusNotes.com</a></p>
-		</footer>
+	</div>
+
+	<script type="text/javascript" src="../js/memoryquiz.js"></script>
+
+	<footer>
+		<p>&copy; 2017 by <a href="contact.html">AirbusNotes.com</a></p>
+	</footer>
 
 </body>
+
 </html>

--- a/html/A320limitations.html
+++ b/html/A320limitations.html
@@ -63,7 +63,7 @@
 					<tfoot>
 						<tr>
 							<td colspan="6">Data source: JetBlue QRH</td>
-						</tr>
+					</tr>
 					</tfoot>
 					<tbody>
 						<tr>
@@ -157,7 +157,7 @@
 								<td>Max</td>
 								<td align="right">-2.0%, +2.0%</td>
 							</tr>
-							<tr style="height: 30px">
+							<tr style="height: 20px">
 								<td><b><i>Limit Maneuvering Load Factors</i></b></td>
 								<td></td>
 							</tr>
@@ -175,7 +175,7 @@
 								<td align="right">0g to +2.0g</td>
 							</tr>
 
-							<tr style="height: 30px"></tr>
+							<tr style="height: 20px"></tr>
 
 							<tr>
 								<td><b><i>Fuel</i></b></td>
@@ -211,75 +211,71 @@
 								<td>In-flight / landing</td>
 								<td align="right">2910 lb (A321)</td>
 							</tr>
-
-							<tr style="height: 30px"></tr>
-
-							<tr>
-								<td>
-									<table>
-										<caption>Speeds</caption>
-										<tr>
-											<td>Max flap speed config 1</td>
-											<td align="right">230 kts (A320) / 235 kts (A321)</td>
-										</tr>
-										<td>Max flap speed config 1+F</td>
-										<td align="right">215 kts(A320)</td>
-										<tr>
-											<td></td>
-											<td align="right">225 kts (A321)</td>
-										</tr>
-										<tr>
-											<td>Max flap speed config 2</td>
-											<td align="right">200 kts (A320)</td>
-										</tr>
-										<tr>
-											<td></td>
-											<td align="right">215 kts (A321)</td>
-										</tr>
-										<tr>
-											<td>Max flap speed config 3</td>
-											<td align="right">185 kts (A320)</td>
-										</tr>
-										<tr>
-											<td></td>
-											<td align="right">195 kts (A321)</td>
-										</tr>
-										<tr>
-											<td>Max flap speed config full</td>
-											<td align="right">177 kts (A320)</td>
-										</tr>
-										<tr>
-											<td></td>
-											<td align="right">190 kts (A321)</td>
-										</tr>
-										<tr>
-											<td>V<sub>LE</sub></td>
-											<td align="right">280 kts / 0.67M</td>
-										</tr>
-										<tr>
-											<td>V<sub>LO extension / retraction</sub></td>
-											<td align="right">250 kts / 220 kts</td>
-										</tr>
-										<tr>
-											<td>V<sub>MO</sub></td>
-											<td align="right">350 kts / 0.82M</td>
-										</tr>
-										<tr>
-											<td>Max cockpit window open speed</td>
-											<td align="right">200 kts</td>
-										</tr>
-										<tr>
-											<td>Max tire speed (ground speed)</td>
-											<td align="right">195 kts</td>
-										</tr>
-										<tr>
-											<td><b>Max windshield wiper speed</b></td>
-											<td align="right"><b>230 kts</b></td>
-										</tr>
-									</table>
-								</td>
-							</tr>
 						</table>
+
+						<div class="tables">
+							<table>
+								<caption>Speeds</caption>
+								<tr>
+									<td>Max flap speed config 1</td>
+									<td align="right">230 kts (A320) / 235 kts (A321)</td>
+								</tr>
+								<td>Max flap speed config 1+F</td>
+								<td align="right">215 kts(A320)</td>
+								<tr>
+									<td></td>
+									<td align="right">225 kts (A321)</td>
+								</tr>
+								<tr>
+									<td>Max flap speed config 2</td>
+									<td align="right">200 kts (A320)</td>
+								</tr>
+								<tr>
+									<td></td>
+									<td align="right">215 kts (A321)</td>
+								</tr>
+								<tr>
+									<td>Max flap speed config 3</td>
+									<td align="right">185 kts (A320)</td>
+								</tr>
+								<tr>
+									<td></td>
+									<td align="right">195 kts (A321)</td>
+								</tr>
+								<tr>
+									<td>Max flap speed config full</td>
+									<td align="right">177 kts (A320)</td>
+								</tr>
+								<tr>
+									<td></td>
+									<td align="right">190 kts (A321)</td>
+								</tr>
+								<tr>
+									<td>V<sub>LE</sub></td>
+									<td align="right">280 kts / 0.67M</td>
+								</tr>
+								<tr>
+									<td>V<sub>LO extension / retraction</sub></td>
+									<td align="right">250 kts / 220 kts</td>
+								</tr>
+								<tr>
+									<td>V<sub>MO</sub></td>
+									<td align="right">350 kts / 0.82M</td>
+								</tr>
+								<tr>
+									<td>Max cockpit window open speed</td>
+									<td align="right">200 kts</td>
+								</tr>
+								<tr>
+									<td>Max tire speed (ground speed)</td>
+									<td align="right">195 kts</td>
+								</tr>
+								<tr>
+									<td><b>Max windshield wiper speed</b></td>
+									<td align="right"><b>230 kts</b></td>
+								</tr>
+							</table>
+						</div>
 
 						<div class="tables">
 							<table>
@@ -321,8 +317,6 @@
 						</table>
 					</div>
 
-					<br>
-
 					<div class="tables">
 						<table>
 							<caption>Electric</caption>
@@ -336,8 +330,6 @@
 							</tr>
 						</table>
 					</div>
-
-					<br>
 
 					<div class="tables">
 						<table>
@@ -356,8 +348,6 @@
 							</tr>
 						</table>
 					</div>
-
-					<br>
 
 					<div class="tables">
 						<table>
@@ -416,8 +406,6 @@
 							</tr>
 						</table>
 					</div>
-
-					<br>
 
 					<div class="tables">
 						<table id="APU">


### PR DESCRIPTION
The markup for this page was shifted around quite a bit, which might make the diff (the different between the old and new) a bit hard to read. Basically you now have all three `.col`  divs inside a single `.container` div, which is critical for the grid to function properly. Now the floats are properly contained and aligned.

I’ve also set all tables in `.tables` divs to always expand to 100%. This will also help with alignment issues. if you want to expand or contract them, make the column narrower or wider. You could make the third one less than 100% if you wanted and it would still sit below the other two.